### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -4,8 +4,6 @@ defmodule UUID do
   See [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
   """
 
-  use Bitwise, only_operators: true
-
   alias UUID.Info
 
   @typedoc "One of representations of UUID."


### PR DESCRIPTION
`use Bitwise` is deprecated. Apparently, its functions are also not used in `UUID`.